### PR TITLE
Use IgnoreEndRevocationUnknown

### DIFF
--- a/mqttclients/dotnet/MQTTnet.Client.Extensions/X509ChainValidator.cs
+++ b/mqttclients/dotnet/MQTTnet.Client.Extensions/X509ChainValidator.cs
@@ -6,7 +6,6 @@ namespace MQTTnet.Client.Extensions
 {
     internal static class X509ChainValidator
     {
-
         internal static bool ValidateChain(MqttClientCertificateValidationEventArgs certValArgs, string caCertFile = "")
         {
             X509Certificate2Collection caCerts = new();
@@ -29,17 +28,23 @@ namespace MQTTnet.Client.Extensions
                 bool chainValidated = false;
                 cvArgs.Chain.Reset();
                 cvArgs.Chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                cvArgs.Chain.ChainPolicy.VerificationFlags = X509VerificationFlags.IgnoreEndRevocationUnknown;
+                
                 cvArgs.Chain.ChainPolicy.CustomTrustStore.AddRange(caChain);
+                Trace.TraceWarning("Validating TLS with chain:\n\t" + string.Join("\n\t",cvArgs.Chain.ChainPolicy.CustomTrustStore.Select(c => c.Subject)));
+
+                cvArgs.Chain.ChainPolicy.VerificationFlags = X509VerificationFlags.IgnoreEndRevocationUnknown | X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown;
+                Trace.TraceWarning($"Chain validation configured with verification flags:\n\t{cvArgs.Chain.ChainPolicy.VerificationFlags}");
+
                 chainValidated = cvArgs.Chain.Build(new X509Certificate2(cvArgs.Certificate));
                 if (chainValidated == false)
                 {
                     Trace.TraceError($"Error validating TLS chain for cert: '{cvArgs.Certificate.Subject}' issued by '{cvArgs.Certificate.Issuer}'");
-                    cvArgs.Chain.ChainStatus.ToList().ForEach(s => Trace.TraceError(s.StatusInformation));
+                    cvArgs.Chain.ChainStatus.ToList().ForEach(s => Trace.TraceError("  " + s.StatusInformation));
                 }
                 return chainValidated;
+
             }
-            Trace.TraceError("RemoteCertificateValidation error:" + cvArgs.SslPolicyErrors);
+            Trace.TraceError("RemoteCertificateValidation Errors: " + cvArgs.SslPolicyErrors);
             return false;
         }
     }

--- a/mqttclients/dotnet/MQTTnet.Client.Extensions/X509ChainValidator.cs
+++ b/mqttclients/dotnet/MQTTnet.Client.Extensions/X509ChainValidator.cs
@@ -32,7 +32,7 @@ namespace MQTTnet.Client.Extensions
                 cvArgs.Chain.ChainPolicy.CustomTrustStore.AddRange(caChain);
                 Trace.TraceWarning("Validating TLS with chain:\n\t" + string.Join("\n\t",cvArgs.Chain.ChainPolicy.CustomTrustStore.Select(c => c.Subject)));
 
-                cvArgs.Chain.ChainPolicy.VerificationFlags = X509VerificationFlags.IgnoreEndRevocationUnknown | X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown;
+                cvArgs.Chain.ChainPolicy.VerificationFlags = X509VerificationFlags.IgnoreEndRevocationUnknown;
                 Trace.TraceWarning($"Chain validation configured with verification flags:\n\t{cvArgs.Chain.ChainPolicy.VerificationFlags}");
 
                 chainValidated = cvArgs.Chain.Build(new X509Certificate2(cvArgs.Certificate));


### PR DESCRIPTION
When validating TLS connections, we dont want to configure the Revocation as NoCheck. Instead, we could use the IgnoreEndRevocationUnknown flag.