### PR TITLE
[C] Fix regression in cmake version in codespaces

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,6 +1,14 @@
 # Install mosquitto client
 sudo apt-add-repository ppa:mosquitto-dev/mosquitto-ppa -y
-sudo apt-get update && sudo apt-get install mosquitto-clients mosquitto ninja-build libmosquitto-dev uuid-dev libjson-c-dev libprotobuf-c-dev -y
+sudo apt-get update && sudo apt-get install mosquitto-clients mosquitto ninja-build libmosquitto-dev uuid-dev libjson-c-dev libprotobuf-c-dev ca-certificates gpg wget -y
+
+# Install CMake (https://apt.kitware.com/)
+wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+sudo apt-get update
+sudo rm /usr/share/keyrings/kitware-archive-keyring.gpg
+sudo apt-get install kitware-archive-keyring
+sudo apt-get install cmake -y
 
 #Install step cli
 wget https://github.com/smallstep/cli/releases/download/v0.24.4/step-cli_0.24.4_amd64.deb

--- a/scenarios/getting_started/c/main.c
+++ b/scenarios/getting_started/c/main.c
@@ -56,9 +56,8 @@ int main(int argc, char* argv[])
   struct mosquitto* mosq;
   int result = MOSQ_ERR_SUCCESS;
 
-  mqtt_client_obj obj;
+  mqtt_client_obj obj = { 0 };
   obj.mqtt_version = MQTT_VERSION;
-  obj.handle_message = NULL;
 
   if ((mosq = mqtt_client_init(true, argv[1], on_connect_with_subscribe, &obj)) == NULL)
   {

--- a/scenarios/getting_started/c/main.c
+++ b/scenarios/getting_started/c/main.c
@@ -58,6 +58,7 @@ int main(int argc, char* argv[])
 
   mqtt_client_obj obj;
   obj.mqtt_version = MQTT_VERSION;
+  obj.handle_message = NULL;
 
   if ((mosq = mqtt_client_init(true, argv[1], on_connect_with_subscribe, &obj)) == NULL)
   {

--- a/scenarios/telemetry/c/telemetry_producer/main.c
+++ b/scenarios/telemetry/c/telemetry_producer/main.c
@@ -34,9 +34,8 @@ int main(int argc, char* argv[])
   struct mosquitto* mosq;
   int result = MOSQ_ERR_SUCCESS;
 
-  mqtt_client_obj obj;
+  mqtt_client_obj obj = { 0 };
   obj.mqtt_version = MQTT_VERSION;
-  obj.handle_message = NULL;
 
   if ((mosq = mqtt_client_init(true, argv[1], NULL, &obj)) == NULL)
   {

--- a/scenarios/telemetry/c/telemetry_producer/main.c
+++ b/scenarios/telemetry/c/telemetry_producer/main.c
@@ -36,6 +36,7 @@ int main(int argc, char* argv[])
 
   mqtt_client_obj obj;
   obj.mqtt_version = MQTT_VERSION;
+  obj.handle_message = NULL;
 
   if ((mosq = mqtt_client_init(true, argv[1], NULL, &obj)) == NULL)
   {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Codespaces no longer has a new enough version of cmake by default - this adds it to the setup steps. Fixes https://github.com/Azure-Samples/MqttApplicationSamples/issues/70
* Also fixes a segfault in the getting started sample

## Checklist
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I will squash my changes into one with a clear description of the change when I complete the PR.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  ...

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->