### PR TITLE
Updated Python samples to use MQTT5

### DIFF
--- a/scenarios/command/python/command_invoker.py
+++ b/scenarios/command/python/command_invoker.py
@@ -157,10 +157,12 @@ def main():
 
     # CONNECT
     print("{}: Starting connection".format(client_id))
-    hostname = connection_settings['MQTT_HOST_NAME']
-    port = connection_settings['MQTT_TCP_PORT']
-    keepalive = connection_settings["MQTT_KEEP_ALIVE_IN_SECONDS"]
-    mqtt_client.connect(hostname, port, keepalive, clean_start=connection_settings['MQTT_CLEAN_SESSION'])
+    mqtt_client.connect(
+        host=connection_settings['MQTT_HOST_NAME'],
+        port=connection_settings['MQTT_TCP_PORT'],
+        keepalive=connection_settings["MQTT_KEEP_ALIVE_IN_SECONDS"],
+        clean_start=connection_settings['MQTT_CLEAN_SESSION'],
+    )
     print("Starting network loop")
     mqtt_client.loop_start()
 

--- a/scenarios/command/python/command_receiver.py
+++ b/scenarios/command/python/command_receiver.py
@@ -148,10 +148,12 @@ def main():
 
     # CONNECT
     print("{}: Starting connection".format(client_id))
-    hostname = connection_settings['MQTT_HOST_NAME']
-    port = connection_settings['MQTT_TCP_PORT']
-    keepalive = connection_settings["MQTT_KEEP_ALIVE_IN_SECONDS"]
-    mqtt_client.connect(hostname, port, keepalive, clean_start=connection_settings['MQTT_CLEAN_SESSION'])
+    mqtt_client.connect(
+        host=connection_settings['MQTT_HOST_NAME'],
+        port=connection_settings['MQTT_TCP_PORT'],
+        keepalive=connection_settings["MQTT_KEEP_ALIVE_IN_SECONDS"],
+        clean_start=connection_settings['MQTT_CLEAN_SESSION'],
+    )
     print("Starting network loop")
     mqtt_client.loop_start()
 

--- a/scenarios/getting_started/python/getting_started.py
+++ b/scenarios/getting_started/python/getting_started.py
@@ -37,7 +37,7 @@ def on_connect(client, _userdata, _flags, rc):
             connection_error = Exception(mqtt.connack_string(rc))
         connected_cond.notify_all()
 
-def on_subscribe(client, _userdata, mid, _granted_qos):
+def on_subscribe(client, _userdata, mid, _reason_codes, _properties):
     global subscribed_prop
     print(f"Subscribe for message id {mid} acknowledged by MQTT broker")
     # # In Paho CB thread.
@@ -104,8 +104,7 @@ def wait_for_disconnected(timeout: float = None):
 def create_mqtt_client(client_id, connection_settings):
     mqtt_client = mqtt.Client(
         client_id=client_id,
-        clean_session=connection_settings['MQTT_CLEAN_SESSION'],
-        protocol=mqtt.MQTTv311,
+        protocol=mqtt.MQTTv5,
         transport="tcp",
     )
     if 'MQTT_USERNAME' in connection_settings:
@@ -154,10 +153,12 @@ mqtt_client.enable_logger()
 
 # CONNECT
 print("{}: Starting connection".format(client_id))
-hostname = connection_settings['MQTT_HOST_NAME']
-port = connection_settings['MQTT_TCP_PORT']
-keepalive = connection_settings["MQTT_KEEP_ALIVE_IN_SECONDS"]
-mqtt_client.connect(hostname, port, keepalive)
+mqtt_client.connect(
+    host=connection_settings['MQTT_HOST_NAME'],
+    port=connection_settings['MQTT_TCP_PORT'],
+    keepalive=connection_settings["MQTT_KEEP_ALIVE_IN_SECONDS"],
+    clean_start=connection_settings['MQTT_CLEAN_SESSION'],
+)
 print("Starting network loop")
 mqtt_client.loop_start()
 

--- a/scenarios/telemetry/python/telemetry_consumer.py
+++ b/scenarios/telemetry/python/telemetry_consumer.py
@@ -36,7 +36,7 @@ def on_connect(client, _userdata, _flags, rc):
             connection_error = Exception(mqtt.connack_string(rc))
         connected_cond.notify_all()
 
-def on_subscribe(client, _userdata, mid, _granted_qos):
+def on_subscribe(client, _userdata, mid, _reason_codes, _properties):
     global subscribed_prop
     print(f"Subscribe for message id {mid} acknowledged by MQTT broker")
     # # In Paho CB thread.
@@ -79,8 +79,7 @@ def wait_for_disconnected(timeout: float = None):
 def create_mqtt_client(client_id, connection_settings):
     mqtt_client = mqtt.Client(
         client_id=client_id,
-        clean_session=connection_settings['MQTT_CLEAN_SESSION'],
-        protocol=mqtt.MQTTv311,
+        protocol=mqtt.MQTTv5,
         transport="tcp",
     )
     if 'MQTT_USERNAME' in connection_settings:
@@ -128,10 +127,12 @@ def main():
 
     try:
         print("{}: Starting connection".format(client_id))
-        hostname = connection_settings['MQTT_HOST_NAME']
-        port = connection_settings['MQTT_TCP_PORT']
-        keepalive = connection_settings["MQTT_KEEP_ALIVE_IN_SECONDS"]
-        mqtt_client.connect(hostname, port, keepalive)
+        mqtt_client.connect(
+            host=connection_settings['MQTT_HOST_NAME'],
+            port=connection_settings['MQTT_TCP_PORT'],
+            keepalive=connection_settings["MQTT_KEEP_ALIVE_IN_SECONDS"],
+            clean_start=connection_settings['MQTT_CLEAN_SESSION']
+        )
         print("Starting network loop")
         mqtt_client.loop_start()
 

--- a/scenarios/telemetry/python/telemetry_producer.py
+++ b/scenarios/telemetry/python/telemetry_producer.py
@@ -66,8 +66,7 @@ def wait_for_disconnected(timeout: float = None):
 def create_mqtt_client(client_id, connection_settings):
     mqtt_client = mqtt.Client(
         client_id=client_id,
-        clean_session=connection_settings['MQTT_CLEAN_SESSION'],
-        protocol=mqtt.MQTTv311,
+        protocol=mqtt.MQTTv5,
         transport="tcp",
     )
     if 'MQTT_USERNAME' in connection_settings:
@@ -115,10 +114,12 @@ def main():
     try:
         # CONNECT
         print("{}: Starting connection".format(client_id))
-        hostname = connection_settings['MQTT_HOST_NAME']
-        port = connection_settings['MQTT_TCP_PORT']
-        keepalive = connection_settings["MQTT_KEEP_ALIVE_IN_SECONDS"]
-        mqtt_client.connect(hostname, port, keepalive)
+        mqtt_client.connect(
+            host=connection_settings['MQTT_HOST_NAME'],
+            port=connection_settings['MQTT_TCP_PORT'],
+            keepalive=connection_settings["MQTT_KEEP_ALIVE_IN_SECONDS"],
+            clean_start=connection_settings["MQTT_CLEAN_SESSION"],
+            )
         print("Starting network loop")
         mqtt_client.loop_start()
 


### PR DESCRIPTION
* Updated Paho client protocol versions from `MQTTv311` to `MQTTv5`
* Modified how `clean_start` (aka `clean_session`) is supplied
* Updated `on_subscribe` callbacks for the expected signature expected when using `MQTTv5`