### PR TITLE
Fix CreateFromEnvVars to allow '=' in env var value.

### DIFF
--- a/mqttclients/dotnet/MQTTnet.Client.Extensions.Tests/MqttConnectionSettingsFixture.cs
+++ b/mqttclients/dotnet/MQTTnet.Client.Extensions.Tests/MqttConnectionSettingsFixture.cs
@@ -94,7 +94,7 @@ public class MqttConnectionSettingsFixture
         Assert.False(cs.CleanSession);
         Assert.Equal(32, cs.KeepAliveInSeconds);
         Assert.Equal("sample_client", cs.ClientId);
-        Assert.Equal("sample_user", cs.Username);
+        Assert.Equal("sample_user/api-version=2024-01-01", cs.Username);
         Assert.Equal("foo", cs.Password);
         Assert.Equal("ca.pem", cs.CaFile);
         Assert.Equal("cert.pem", cs.CertFile);
@@ -132,13 +132,19 @@ public class MqttConnectionSettingsFixture
     {
         foreach (var line in File.ReadAllLines(envFile))
         {
-            var parts = line.Split('=', StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length != 2)
+            int index = line.IndexOf('=');
+            if (index < 0)
             {
                 continue;
             }
 
-            Environment.SetEnvironmentVariable(parts[0], null);
+            string key = line[..index].Trim();
+            if (string.IsNullOrEmpty(key))
+            {
+                continue;
+            }
+
+            Environment.SetEnvironmentVariable(key, null);
         }
     }
 }

--- a/mqttclients/dotnet/MQTTnet.Client.Extensions.Tests/all_settings.txt
+++ b/mqttclients/dotnet/MQTTnet.Client.Extensions.Tests/all_settings.txt
@@ -4,7 +4,7 @@ MQTT_USE_TLS=false
 MQTT_CLEAN_SESSION=false
 MQTT_KEEP_ALIVE_IN_SECONDS=32
 MQTT_CLIENT_ID=sample_client
-MQTT_USERNAME=sample_user
+MQTT_USERNAME=sample_user/api-version=2024-01-01
 MQTT_PASSWORD=foo
 MQTT_CA_FILE=ca.pem
 MQTT_CERT_FILE=cert.pem

--- a/mqttclients/dotnet/MQTTnet.Client.Extensions/MqttConnectionSettings.cs
+++ b/mqttclients/dotnet/MQTTnet.Client.Extensions/MqttConnectionSettings.cs
@@ -61,13 +61,20 @@ public class MqttConnectionSettings
             Trace.TraceInformation("Loading environment variables from {envFile}" + new FileInfo(envFile).FullName);
             foreach (string line in File.ReadAllLines(envFile))
             {
-                string[] parts = line.Split('=', StringSplitOptions.RemoveEmptyEntries);
-                if (parts.Length != 2)
+                int index = line.IndexOf('=');
+                if (index < 0)
                 {
                     continue;
                 }
 
-                Environment.SetEnvironmentVariable(parts[0], parts[1]);
+                string key = line[..index].Trim();
+                string value = line[(index + 1)..].Trim();
+                if (string.IsNullOrEmpty(value) || string.IsNullOrEmpty(key))
+                {
+                    continue;
+                }
+
+                Environment.SetEnvironmentVariable(key, value);
             }
         }
         else


### PR DESCRIPTION
## Purpose
Fix issue #95. Read environment variables that contain an '=' in the value.

## Checklist
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [ ] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I will squashed my changes into one with a clear description of the change when I complete the PR.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Run MqttConnectionSettings unit tests.
